### PR TITLE
깨진 링크 수정

### DIFF
--- a/7.md
+++ b/7.md
@@ -1,1 +1,1 @@
-[Hactoberfest Seoul Meetup!](https://event-us.kr/hacktoberfestseoul/event/23432)
+[Hactoberfest Seoul Meetup!](https://event-us.kr/hacktoberfestkorea/event/23432)


### PR DESCRIPTION
핵토버페스트 이벤터스 웹사이트 링크가 깨져서 변경했습니다.